### PR TITLE
Add option to `build` to build all targets

### DIFF
--- a/CHANGELOD.md
+++ b/CHANGELOD.md
@@ -6,9 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- New build report to show output file name, elapsed time, and total ouput size.
+- New build report to show output file name, elapsed time, and total output size.
 ### Changed
 - Error handling to better highlight what caused an error to occur. An error will now display a list of causes, in order.
+- `boon build` learned how to build all supported targets at the same time using the `--target all` option.
 ### Fixed
 - `boon love download` no longer makes an extra unnecessary HTTP request when downloading LÖVE which should improve performance.
 - `boon --version` now displays the correct release version.


### PR DESCRIPTION
Added an option to `boon build` to build all supported targets at the same time.