### PR TITLE
Remove duplicate ignore list entries

### DIFF
--- a/CHANGELOD.md
+++ b/CHANGELOD.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `boon --version` now displays the correct release version.
 - Unnecessary references (pointers) to small integers values have been removed, slightly improving performance.
 - Library dependencies have been updated, improving performance and fixing many issues.
+- Duplicate entries in the ignore list when merging default and project configuration, removing unneeded work on build.
 
 ## [0.1.1] - 2020-02-11
 ### Fixed

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -26,6 +26,7 @@ use std::io::{Seek, Write};
 use std::iter::Iterator;
 
 use anyhow::{ensure, Context, Result};
+use std::collections::HashSet;
 use std::fs::File;
 use std::path::{Path, PathBuf};
 use walkdir::{DirEntry, WalkDir};
@@ -169,7 +170,7 @@ pub fn create_love(project: &Project, build_settings: &BuildSettings) -> Result<
     })
 }
 
-fn should_exclude_file(file_name: &str, ignore_list: &[String]) -> bool {
+fn should_exclude_file(file_name: &str, ignore_list: &HashSet<String>) -> bool {
     for exclude_pattern in ignore_list {
         // @Performance @TODO: Could cache regex in a multi-build to
         // avoid recompiling the same patterns
@@ -187,7 +188,7 @@ fn zip_directory<T>(
     prefix: &str,
     writer: T,
     method: zip::CompressionMethod,
-    ignore_list: &[String],
+    ignore_list: &HashSet<String>,
 ) -> zip::result::ZipResult<()>
 where
     T: Write + Seek,
@@ -226,7 +227,7 @@ fn collect_zip_directory(
     src_dir: &str,
     dst_file: &str,
     method: zip::CompressionMethod,
-    ignore_list: &[String],
+    ignore_list: &HashSet<String>,
 ) -> Result<zip::result::ZipResult<()>> {
     if !Path::new(src_dir).is_dir() {
         return Err(anyhow::Error::from(ZipError::FileNotFound));

--- a/src/build/windows.rs
+++ b/src/build/windows.rs
@@ -4,6 +4,7 @@ use glob::glob;
 use remove_dir_all::*;
 
 use anyhow::{anyhow, ensure, Context, Result};
+use std::collections::HashSet;
 use std::fs::File;
 use std::io::{Read, Write};
 use std::path::PathBuf;
@@ -151,14 +152,18 @@ pub fn create_exe(
         .to_str()
         .context("Could not do string conversion")?;
 
-    collect_zip_directory(src_dir, dst_file, zip::CompressionMethod::Deflated, &[]).with_context(
-        || {
-            format!(
-                "Error while zipping files from `{}` to `{}`",
-                src_dir, dst_file
-            )
-        },
-    )??;
+    collect_zip_directory(
+        src_dir,
+        dst_file,
+        zip::CompressionMethod::Deflated,
+        &HashSet::new(),
+    )
+    .with_context(|| {
+        format!(
+            "Error while zipping files from `{}` to `{}`",
+            src_dir, dst_file
+        )
+    })??;
     let path = PathBuf::new().join(src_dir);
     println!("Removing {}", path.display());
     remove_dir_all(&path)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ use config::Config;
 use humansize::{file_size_opts, FileSize};
 use prettytable::{cell, row, Table};
 use remove_dir_all::*;
+use std::collections::HashSet;
 use std::fs::File;
 use std::path::{Path, PathBuf};
 use walkdir::WalkDir;
@@ -145,7 +146,7 @@ fn get_settings() -> Result<(Config, BuildSettings)> {
         BOON_CONFIG_FILE_NAME
     ))?;
 
-    let mut ignore_list: Vec<String> = settings.get("build.ignore_list").unwrap();
+    let mut ignore_list: HashSet<String> = settings.get("build.ignore_list").unwrap();
     if Path::new(BOON_CONFIG_FILE_NAME).exists() {
         // Add in `./Boon.toml`
         settings
@@ -155,12 +156,12 @@ fn get_settings() -> Result<(Config, BuildSettings)> {
                 BOON_CONFIG_FILE_NAME
             ))?;
 
-        let mut project_ignore_list: Vec<String> = settings.get("build.ignore_list").unwrap();
+        let project_ignore_list: HashSet<String> = settings.get("build.ignore_list").unwrap();
 
         if settings.get("build.exclude_default_ignore_list").unwrap() {
             ignore_list = project_ignore_list;
         } else {
-            ignore_list.append(&mut project_ignore_list);
+            ignore_list.extend(project_ignore_list);
         }
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,11 +1,12 @@
 #![allow(clippy::use_debug)]
+use std::collections::HashSet;
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 
 #[derive(Debug, Clone)]
 pub struct BuildSettings {
     pub output_directory: String,
-    pub ignore_list: Vec<String>,
+    pub ignore_list: HashSet<String>,
     pub exclude_default_ignore_list: bool,
 }
 


### PR DESCRIPTION
Noticed that there were duplicate entries in the ignore list, which is not harmful, but it is unncessary work. So, the ignore list now uses a hash set of strings to guarantee ignore list uniqueness across the default and project configuration settings.