### PR TITLE
Add support for targets in config file

### DIFF
--- a/Boon.toml
+++ b/Boon.toml
@@ -62,6 +62,10 @@ ignore_list = [
     "release",
 ]
 
+# List of targets to build for
+# Possible values: "love", "windows", "macos", "all"
+targets = ["love"]
+
 # If this is set to true, then the default ignore list will not be
 # merged with the project specific ignore list. This allows the
 # ignore list to be completely overwritten.

--- a/src/types.rs
+++ b/src/types.rs
@@ -11,6 +11,7 @@ pub struct BuildSettings {
     pub output_directory: String,
     pub ignore_list: HashSet<String>,
     pub exclude_default_ignore_list: bool,
+    pub targets: Vec<Target>,
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
This PR allows the user to specify a list of targets in Boon.toml as suggested in #17.

Few things to note about this implementation
- The user is allowed to redundantly specify lists such as `["all", "windows"]`
- Using the `--target` flag will overwrite the targets config option (you can only specify a single target in the command line)
- If you do `--target love` it won't overwrite the config option
- You can't specify a string like `targets = "all"`, has to be a list `targets = ["all"]`