### PR TITLE
Fixes a bug in the default ignore list and some compiler warnings

### DIFF
--- a/Boon.toml
+++ b/Boon.toml
@@ -58,8 +58,8 @@ ignore_list = [
     ".exe$",
 
     # Boon-specific files and directories
-    "Boon.toml",
-    "release",
+    "Boon.toml$",
+    "^release$",
 ]
 
 # List of targets to build for

--- a/Boon.toml
+++ b/Boon.toml
@@ -58,7 +58,7 @@ ignore_list = [
     ".exe$",
 
     # Boon-specific files and directories
-    "Boon.toml$",
+    "^Boon.toml$",
     "^release$",
 ]
 

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -209,7 +209,7 @@ where
                 ignore_list,
             )
         {
-            zip.start_file_from_path(name, options)?;
+            zip.start_file(name.to_str().expect("Could not do string conversion"), options)?;
             let mut f = File::open(path)?;
 
             f.read_to_end(&mut buffer)?;

--- a/src/download.rs
+++ b/src/download.rs
@@ -73,7 +73,7 @@ pub fn download_love(version: LoveVersion, platform: Platform, bitness: Bitness)
                 .unwrap_or_else(|_| panic!("Could not get archive file by index '{}'", i));
             let mut outpath = output_file_path.clone();
             outpath.pop();
-            outpath.push(file.sanitized_name());
+            outpath.push(file.mangled_name());
 
             if file.name().ends_with('/') {
                 std::fs::create_dir_all(&outpath).expect("Could not create output directory path");

--- a/src/download.rs
+++ b/src/download.rs
@@ -73,7 +73,7 @@ pub fn download_love(version: LoveVersion, platform: Platform, bitness: Bitness)
                 .unwrap_or_else(|_| panic!("Could not get archive file by index '{}'", i));
             let mut outpath = output_file_path.clone();
             outpath.pop();
-            outpath.push(file.mangled_name());
+            outpath.push(file.enclosed_name().expect("Failed to get well-formed zip file entry path."));
 
             if file.name().ends_with('/') {
                 std::fs::create_dir_all(&outpath).expect("Could not create output directory path");

--- a/src/main.rs
+++ b/src/main.rs
@@ -350,7 +350,7 @@ fn build(
     }
 
     // Display build report
-    display_build_report(stats_list).context("Failed to display build report")?;
+    display_build_report(stats_list);
 
     Ok(())
 }
@@ -395,7 +395,7 @@ fn build_love(
     Ok(())
 }
 
-fn display_build_report(build_stats: Vec<BuildStatistics>) -> Result<()> {
+fn display_build_report(build_stats: Vec<BuildStatistics>) {
     let mut build_report_table = Table::new();
     build_report_table.set_format(*prettytable::format::consts::FORMAT_NO_BORDER_LINE_SEPARATOR);
     build_report_table.set_titles(row!["Build", "File", "Time", "Size"]);
@@ -420,7 +420,6 @@ fn display_build_report(build_stats: Vec<BuildStatistics>) -> Result<()> {
 
     println!();
     build_report_table.printstd();
-    Ok(())
 }
 
 fn get_installed_love_versions() -> Result<Vec<String>> {


### PR DESCRIPTION
This pattern causes the default `ignore_list` to ignore not only the `release` folder, but also assets and files named `foo-released.ogg` and `quest-release-me.lua`.
