### PR TITLE
Add links and identifiers for Löve 11.4

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -62,7 +62,7 @@ jobs:
       asset_name: boon-linux-amd64
     strategy:
       matrix:
-        love: [11.2, 11.3, 0.10.2]
+        love: [11.2, 11.3, 11.4, 0.10.2]
     steps:
       - uses: actions/checkout@v2
       - name: Download latest boon
@@ -97,7 +97,7 @@ jobs:
       asset_name: boon-macos-amd64
     strategy:
       matrix:
-        love: [11.2, 11.3, 0.10.2]
+        love: [11.2, 11.3, 11.4, 0.10.2]
     steps:
       - uses: actions/checkout@v2
       - name: Download latest boon
@@ -130,7 +130,7 @@ jobs:
       asset_name: boon-windows-amd64
     strategy:
       matrix:
-        love: [11.2, 11.3, 0.10.2]
+        love: [11.2, 11.3, 11.4, 0.10.2]
     steps:
       - uses: actions/checkout@v2
       - name: Download latest boon

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ If you don't initialize boon, you can still build your project normally, but the
 In order to build your project, you first need to download the versionof LÖVE that you are using for it.
 
 ```bash
-# Will download LÖVE 11.3 for building
-$ boon love download 11.3
+# Will download LÖVE 11.4 for building
+$ boon love download 11.4
 ```
 
 ### Building your project

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -38,6 +38,9 @@ pub fn get_love_version_file_name(
     bitness: Bitness,
 ) -> String {
     match (version, platform, bitness) {
+        (LoveVersion::V11_4, Platform::Windows, Bitness::X64) => "love-11.4-win64",
+        (LoveVersion::V11_4, Platform::Windows, Bitness::X86) => "love-11.4-win32",
+
         (LoveVersion::V11_3, Platform::Windows, Bitness::X64) => "love-11.3-win64",
         (LoveVersion::V11_3, Platform::Windows, Bitness::X86) => "love-11.3-win32",
 

--- a/src/download.rs
+++ b/src/download.rs
@@ -112,6 +112,10 @@ fn get_love_download_location(
 ) -> Result<LoveDownloadLocation> {
     let release_location = "https://github.com/love2d/love/releases/download";
     let (version_string, release_file_name) = match (version, platform, bitness) {
+        (LoveVersion::V11_4, Platform::Windows, Bitness::X64) => ("11.4", "love-11.4-win64.zip"),
+        (LoveVersion::V11_4, Platform::Windows, Bitness::X86) => ("11.4", "love-11.4-win32.zip"),
+        (LoveVersion::V11_4, Platform::MacOs, Bitness::X64) => ("11.4", "love-11.4-macos.zip"),
+
         (LoveVersion::V11_3, Platform::Windows, Bitness::X64) => ("11.3", "love-11.3-win64.zip"),
         (LoveVersion::V11_3, Platform::Windows, Bitness::X86) => ("11.3", "love-11.3-win32.zip"),
         (LoveVersion::V11_3, Platform::MacOs, Bitness::X64) => ("11.3", "love-11.3-macos.zip"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,7 @@ enum BoonOpt {
             short,
             help = "Specify which target version of LÖVE to build for",
             possible_values=&LoveVersion::variants(),
-            default_value="11.3",
+            default_value="11.4",
         )]
         version: LoveVersion,
         directory: String,

--- a/src/types.rs
+++ b/src/types.rs
@@ -42,15 +42,16 @@ pub enum Bitness {
     X64, // 64 bit
 }
 
-const LOVE_VERSIONS: [&str; 5] = ["11.3", "11.2", "11.1", "11.0", "0.10.2"];
+const LOVE_VERSIONS: [&str; 6] = ["11.4", "11.3", "11.2", "11.1", "11.0", "0.10.2"];
 /// Represents a specific version of LÖVE2D
 #[derive(Copy, Clone, Debug, Primitive)]
 pub enum LoveVersion {
-    V11_3 = 0,
-    V11_2 = 1,
-    V11_1 = 2,
-    V11_0 = 3,
-    V0_10_2 = 4,
+    V11_4 = 0,
+    V11_3 = 1,
+    V11_2 = 2,
+    V11_1 = 3,
+    V11_0 = 4,
+    V0_10_2 = 5,
 }
 
 /// File info about remote download
@@ -86,7 +87,7 @@ impl FromStr for LoveVersion {
 }
 
 impl LoveVersion {
-    pub const fn variants() -> [&'static str; 5] {
+    pub const fn variants() -> [&'static str; 6] {
         LOVE_VERSIONS
     }
 }


### PR DESCRIPTION
Hi!

I was missing 11.4 support, I've added the needed references where applicable. There's also 12.0 coming up in not too much time. No release planned yet, but the project board is getting empty :-).

Would be cool if this project gets that Linux AppImage build option too.